### PR TITLE
Proposal to add Config file to the Sidebar in Forestry

### DIFF
--- a/site/.forestry/settings.yml
+++ b/site/.forestry/settings.yml
@@ -9,6 +9,12 @@ sections:
   label: Products
   create: all
   match: "**/*"
+- type: heading
+  label: Site Settings
+- type: document
+  path: site/config.toml
+  label: Configuration
+  match: "**/*"
 upload_dir: snipcart-hugo-demo
 public_path: ''
 front_matter_path: ''


### PR DESCRIPTION
When people add the repository to Forestry they can't necessarily do anything from within Forestry but if they are new they also don't quite understand that everything might be stored in their repository. To reduce possible frustration I'm proposing to add this configuration file to the Sidebar.